### PR TITLE
Fix copy review fail.

### DIFF
--- a/_posts/2016-04-01-april.md
+++ b/_posts/2016-04-01-april.md
@@ -10,13 +10,9 @@ The primary site, where both the primary and replica databases are, informed us 
 
 Initially, we thought we'd only have to [move a database to a different room](https://github.com/openstreetmap/operations/issues/67). However, due to all of our networking being in a single room, it was not possible to keep anything at IC available over the weekend.
 
-Given that [it's not 2011 any more](https://blog.openstreetmap.org/2011/06/28/q3-2011-service-reductions/), we felt that this was not acceptable. Many thanks to [Bytemark hosting](https://twitter.com/bytemark/status/729698435339853824) who stepped into the breach and allowed us to [move some servers](https://github.com/openstreetmap/operations/issues?q=milestone%3A%22Server+Moves%22) there. With a primary database server hosted at Bytemark, and the replica in IC, we now have multi-site redundancy, although it is still a complicated matter to switch database primaries.
-
-Thanks, also, to OSMF-US, who allowed us to use some of their AWS credits to fund a third replica in the cloud, just in case anything went horribly wrong with the move.
-
 # New database server purchase
 
-A new database server, [karm](https://hardware.openstreetmap.org/servers/karm.openstreetmap.org/) was purchased. This is OSM's first all-solid-state server, and should provide both faster API and website access and fewer maintenance issues. The new server is [being tested](https://github.com/openstreetmap/operations/issues/78) while we make sure it's configured for best performance.
+A new database server, [karm](https://hardware.openstreetmap.org/servers/karm.openstreetmap.org/) was purchased. This is OSM's first all-solid-state server, and should provide both faster API and website access and fewer maintenance issues.
 
 # Disks failed in Ramoth
 

--- a/_posts/2016-05-01-may.md
+++ b/_posts/2016-05-01-may.md
@@ -6,11 +6,15 @@ date: 2016-05-31 23:59:59
 
 # IC Electrical Testing
 
-https://github.com/openstreetmap/operations/issues?q=milestone%3A%22Server+Moves%22
+Electrical maintenance at IC would have resulted in a total outage (either network or power) of all machines there.
+
+Given that [it's not 2011 any more](https://blog.openstreetmap.org/2011/06/28/q3-2011-service-reductions/), we felt that this was not acceptable. Many thanks to [Bytemark hosting](https://twitter.com/bytemark/status/729698435339853824) who stepped into the breach and allowed us to [move some servers](https://github.com/openstreetmap/operations/issues?q=milestone%3A%22Server+Moves%22) there. With a primary database server hosted at Bytemark, and the replica in IC, we now have multi-site redundancy, although it is still a complicated matter to switch database primaries.
+
+Thanks, also, to OSMF-US, who allowed us to use some of their AWS credits to fund a third replica in the cloud, just in case anything went horribly wrong with the move.
 
 # New server arrives
 
-https://github.com/openstreetmap/operations/issues/76
+The new database server arrived, and was [racked up and installed](https://github.com/openstreetmap/operations/issues/76). The new server is [being tested](https://github.com/openstreetmap/operations/issues/78) while we make sure it's configured for best performance.
 
 # Electrical test aftermath
 


### PR DESCRIPTION
Move copy around so that there are no bare links. Some of this stuff happened in May anyway. It's a bit annoying to have the stuff split across two months, but that's how it happened.